### PR TITLE
corrections mineures dans les chemins relatifs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ doit être lancé.
 
 Compiler le CSS :
 
-	$ cd sass
+	$ cd biciklo/sass
 	$ compass compile
-	$ cd ..
+	$ cd ../..
 
 Lancer le site Flask :
 
-	$ BICIKLO_DEBUG=1 python index.py
+	$ BICIKLO_DEBUG=1 python biciklo/biciklo.py
 
-`index.py` imprimera l'URL qui permet l'accès au site Web.
+`biciklo.py` imprimera l'URL qui permet l'accès au site Web.
 
 
 API HTTP

--- a/biciklo/biciklo.py
+++ b/biciklo/biciklo.py
@@ -20,7 +20,7 @@ from flask import request
 from flask import render_template
 from flask import url_for
 
-from biciklo import db
+import db
 
 app = Flask(__name__)
 


### PR DESCRIPTION
Il y a un peu de confusion quant aux chemins relatifs. Dans le README.md ce n'est pas clair si les instructions sont par rapport au répertoire racine où non.

 index.py s'appelle maintenant biciklo.py

la ligne 
   from biciklo import db
ne fonctionne pas. C'est peut-être parce que biciklo.py et db.py sont au même niveau.
